### PR TITLE
Fix: Add dotenv and update backend setup

### DIFF
--- a/hireConnect-backend-api/package-lock.json
+++ b/hireConnect-backend-api/package-lock.json
@@ -14,6 +14,7 @@
         "connect-pg-simple": "^10.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
         "express-session": "^1.18.1",
@@ -39,7 +40,6 @@
         "@types/jest": "^30.0.0",
         "@types/supertest": "^6.0.3",
         "babel-jest": "^30.0.2",
-        "dotenv": "^16.6.1",
         "jest": "^30.0.3",
         "prisma": "^5.14.0",
         "supertest": "^7.1.1"
@@ -3606,10 +3606,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/hireConnect-backend-api/package.json
+++ b/hireConnect-backend-api/package.json
@@ -39,6 +39,7 @@
     "connect-pg-simple": "^10.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
     "express-session": "^1.18.1",
@@ -64,7 +65,6 @@
     "@types/jest": "^30.0.0",
     "@types/supertest": "^6.0.3",
     "babel-jest": "^30.0.2",
-    "dotenv": "^16.6.1",
     "jest": "^30.0.3",
     "prisma": "^5.14.0",
     "supertest": "^7.1.1"


### PR DESCRIPTION
Moved dotenv to dependencies for production use

Removed yarn.lock to ensure npm is used

Updated backend setup for Render deployment compatibility